### PR TITLE
VIVI-8080 Allow null workstation

### DIFF
--- a/cntlm/trunk/configure
+++ b/cntlm/trunk/configure
@@ -53,7 +53,7 @@ fi
 
 STAMP=configure-stamp
 CONFIG=config/config.h
-TESTS="endian strdup socklen_t" # endian strdup, socklen_t gethostname
+TESTS="endian strdup socklen_t gethostname"
 
 #[ -f $STAMP ] && exit 0
 touch $STAMP

--- a/cntlm/trunk/configure
+++ b/cntlm/trunk/configure
@@ -53,7 +53,7 @@ fi
 
 STAMP=configure-stamp
 CONFIG=config/config.h
-TESTS="endian strdup socklen_t gethostname"
+TESTS="endian strdup socklen_t" # endian strdup, socklen_t gethostname
 
 #[ -f $STAMP ] && exit 0
 touch $STAMP

--- a/cntlm/trunk/direct.c
+++ b/cntlm/trunk/direct.c
@@ -66,7 +66,7 @@ int www_authenticate(int sd, rr_data_t request, rr_data_t response, struct auth_
 	buf = new(BUFSIZE);
 
 	strcpy(buf, "NTLM ");
-	len = ntlm_request(&tmp, creds);
+	len = ntlm_request(&tmp, creds, ntlm_clean_negotiation);
 	if (len) {
 		to_base64(MEM(buf, uint8_t, 5), MEM(tmp, uint8_t, 0), len, BUFSIZE-5);
 		free(tmp);

--- a/cntlm/trunk/forward.c
+++ b/cntlm/trunk/forward.c
@@ -144,7 +144,7 @@ int proxy_authenticate(int *sd, rr_data_t request, rr_data_t response, struct au
 	buf = new(BUFSIZE);
 
 	strcpy(buf, "NTLM ");
-	len = ntlm_request(&tmp, credentials);
+	len = ntlm_request(&tmp, credentials, ntlm_clean_negotiation);
 	if (len) {
 		to_base64(MEM(buf, uint8_t, 5), MEM(tmp, uint8_t, 0), len, BUFSIZE-5);
 		free(tmp);

--- a/cntlm/trunk/globals.h
+++ b/cntlm/trunk/globals.h
@@ -35,7 +35,7 @@ extern int debug;
 extern struct auth_s *g_creds;			/* global NTLM credentials */
 
 extern int ntlmbasic;				/* forward_request() */
-extern int use_px_mode; 		/* replicate px proxy behaviour */
+extern int ntlm_clean_negotiation;
 extern int allow_null_workstation;
 extern int serialize;
 extern int scanner_plugin;

--- a/cntlm/trunk/globals.h
+++ b/cntlm/trunk/globals.h
@@ -35,6 +35,8 @@ extern int debug;
 extern struct auth_s *g_creds;			/* global NTLM credentials */
 
 extern int ntlmbasic;				/* forward_request() */
+extern int use_px_mode; 		/* replicate px proxy behaviour */
+extern int allow_null_workstation;
 extern int serialize;
 extern int scanner_plugin;
 extern long scanner_plugin_maxsize;

--- a/cntlm/trunk/main.c
+++ b/cntlm/trunk/main.c
@@ -1145,8 +1145,6 @@ int main(int argc, char **argv) {
 #if config_gethostname == 1
 		gethostname(cworkstation, MINIBUF_SIZE);
 #endif
-		if (!strlen(cworkstation))
-			strlcpy(cworkstation, "cntlm", MINIBUF_SIZE);
 
 		syslog(LOG_INFO, "Workstation name used: %s\n", cworkstation);
 	}

--- a/cntlm/trunk/main.c
+++ b/cntlm/trunk/main.c
@@ -73,6 +73,7 @@ struct auth_s *g_creds = NULL;			/* throughout the whole module */
 
 int quit = 0;					/* sighandler() */
 int ntlmbasic = 0;				/* forward_request() */
+int use_px_mode = 0; 			/* replicate px proxy behaviour */
 int allow_null_workstation = 0;
 int serialize = 0;
 int scanner_plugin = 0;
@@ -995,6 +996,15 @@ int main(int argc, char **argv) {
 		free(tmp);
 
 		/*
+		 * Check if should replicate px proxy behaviour
+		 */
+		tmp = new(MINIBUF_SIZE);
+		CFG_DEFAULT(cf, "PXMode", tmp, MINIBUF_SIZE);
+		if (!strcasecmp("yes", tmp))
+			use_px_mode = 1;
+		free(tmp);
+
+		/*
 		 * Check if allow null workstation setting
 		 */
 		tmp = new(MINIBUF_SIZE);
@@ -1148,9 +1158,9 @@ int main(int argc, char **argv) {
 	if (!interactivehash && !magic_detect && !proxyd_list)
 		croak("No proxy service ports were successfully opened.\n", interactivepwd);
 
-		/*
-		 * Set default value for the workstation if null not allowed. Hostname if possible.
-		 */
+	/*
+	 * Set default value for the workstation. Hostname if possible.
+	 */
 	if (!allow_null_workstation && !strlen(cworkstation)) {
 #if config_gethostname == 1
 		gethostname(cworkstation, MINIBUF_SIZE);

--- a/cntlm/trunk/main.c
+++ b/cntlm/trunk/main.c
@@ -73,7 +73,7 @@ struct auth_s *g_creds = NULL;			/* throughout the whole module */
 
 int quit = 0;					/* sighandler() */
 int ntlmbasic = 0;				/* forward_request() */
-int use_px_mode = 0; 			/* replicate px proxy behaviour */
+int ntlm_clean_negotiation = 0;
 int allow_null_workstation = 0;
 int serialize = 0;
 int scanner_plugin = 0;
@@ -999,9 +999,9 @@ int main(int argc, char **argv) {
 		 * Check if should replicate px proxy behaviour
 		 */
 		tmp = new(MINIBUF_SIZE);
-		CFG_DEFAULT(cf, "PXMode", tmp, MINIBUF_SIZE);
+		CFG_DEFAULT(cf, "NTLMCleanNegotiation", tmp, MINIBUF_SIZE);
 		if (!strcasecmp("yes", tmp))
-			use_px_mode = 1;
+			ntlm_clean_negotiation = 1;
 		free(tmp);
 
 		/*

--- a/cntlm/trunk/ntlm.c
+++ b/cntlm/trunk/ntlm.c
@@ -240,13 +240,13 @@ int ntlm_request(char **dst, struct auth_s *creds) {
 	} else
 		flags = creds->flags;
 
-		// If no domain, flip NTLMSSP_NEGOTIATE_OEM_DOMAIN_SUPPLIED (to false)
+		// If no domain, clear NTLMSSP_NEGOTIATE_OEM_DOMAIN_SUPPLIED
 		if (dlen < 1) {
-			flags ^= 0x00001000;
+			flags &= ~0x00001000;
 		}
-		// if no workstation, flip NTLMSSP_NEGOTIATE_OEM_WORKSTATION_SUPPLIED (to false)
+		// if no workstation, clear NTLMSSP_NEGOTIATE_OEM_WORKSTATION_SUPPLIED
 		if (hlen < 1) {
-			flags ^= 0x00002000;
+			flags &= ~0x00002000;
 		}
 
 	if (debug) {

--- a/cntlm/trunk/ntlm.c
+++ b/cntlm/trunk/ntlm.c
@@ -220,7 +220,9 @@ int ntlm_request(char **dst, struct auth_s *creds) {
 
 	if (!creds->flags) {
 		if (creds->hashntlm2)
-			flags = 0xa208b205;
+			// We drop NTLMSSP_NEGOTIATE_56 & NTLMSSP_NEGOTIATE_128 from 0xa208b205
+			// TODO: Only drop if optional config flags set
+			flags = 0x0008b207;
 		else if (creds->hashnt == 2)
 			flags = 0xa208b207;
 		else if (creds->hashnt && creds->hashlm)
@@ -238,6 +240,15 @@ int ntlm_request(char **dst, struct auth_s *creds) {
 		}
 	} else
 		flags = creds->flags;
+
+		// If no domain, drop NTLMSSP_NEGOTIATE_OEM_DOMAIN_SUPPLIED
+		if (dlen < 1) {
+			// TODO: change 0x0000B000 -> 0x00008000 in flags.
+		}
+		// if no workstation, drop NTLMSSP_NEGOTIATE_OEM_WORKSTATION_SUPPLIED
+		if (hlen < 1) {
+			// TODO: change 0x0000B000 -> 0x00008000 in flags.
+		}
 
 	if (debug) {
 		printf("NTLM Request:\n");

--- a/cntlm/trunk/ntlm.c
+++ b/cntlm/trunk/ntlm.c
@@ -220,7 +220,10 @@ int ntlm_request(char **dst, struct auth_s *creds) {
 
 	if (!creds->flags) {
 		if (creds->hashntlm2)
-			// We drop NTLMSSP_NEGOTIATE_56 & NTLMSSP_NEGOTIATE_128 from 0xa208b205
+			// cntlm default: flags = 0xa208b205
+			// 0xa0000000 -> 0x00000000 (clear NTLMSSP_NEGOTIATE_56, NTLMSSP_NEGOTIATE_128)
+			// 0x02000000 -> 0x00000000 (clear NTLMSSP_NEGOTIATE_VERSION)
+			// 0x00000005 -> 0x00000007 (set NTLMSSP_NEGOTIATE_UNICODE)
 			flags = 0x0008b207; // TODO: Only drop if optional config flags set
 		else if (creds->hashnt == 2)
 			flags = 0xa208b207;

--- a/cntlm/trunk/ntlm.c
+++ b/cntlm/trunk/ntlm.c
@@ -221,8 +221,7 @@ int ntlm_request(char **dst, struct auth_s *creds) {
 	if (!creds->flags) {
 		if (creds->hashntlm2)
 			// We drop NTLMSSP_NEGOTIATE_56 & NTLMSSP_NEGOTIATE_128 from 0xa208b205
-			// TODO: Only drop if optional config flags set
-			flags = 0x0008b207;
+			flags = 0x0008b207; // TODO: Only drop if optional config flags set
 		else if (creds->hashnt == 2)
 			flags = 0xa208b207;
 		else if (creds->hashnt && creds->hashlm)
@@ -241,13 +240,13 @@ int ntlm_request(char **dst, struct auth_s *creds) {
 	} else
 		flags = creds->flags;
 
-		// If no domain, drop NTLMSSP_NEGOTIATE_OEM_DOMAIN_SUPPLIED
+		// If no domain, flip NTLMSSP_NEGOTIATE_OEM_DOMAIN_SUPPLIED (to false)
 		if (dlen < 1) {
-			// TODO: change 0x0000B000 -> 0x00008000 in flags.
+			flags ^= 0x00001000;
 		}
-		// if no workstation, drop NTLMSSP_NEGOTIATE_OEM_WORKSTATION_SUPPLIED
+		// if no workstation, flip NTLMSSP_NEGOTIATE_OEM_WORKSTATION_SUPPLIED (to false)
 		if (hlen < 1) {
-			// TODO: change 0x0000B000 -> 0x00008000 in flags.
+			flags ^= 0x00002000;
 		}
 
 	if (debug) {

--- a/cntlm/trunk/ntlm.c
+++ b/cntlm/trunk/ntlm.c
@@ -28,7 +28,6 @@
 #include "swap.h"
 #include "xcrypt.h"
 #include "utils.h"
-#include "globals.h"
 #include "auth.h"
 
 extern int debug;
@@ -209,7 +208,7 @@ char *ntlm2_hash_password(char *username, char *domain, char *password) {
 	return passnt2;
 }
 
-int ntlm_request(char **dst, struct auth_s *creds) {
+int ntlm_request(char **dst, struct auth_s *creds, int ntlm_clean_negotiation) {
 	char *buf, *tmp;
 	int dlen, hlen;
 	uint32_t flags = 0xb206;

--- a/cntlm/trunk/ntlm.h
+++ b/cntlm/trunk/ntlm.h
@@ -31,7 +31,7 @@
 extern char *ntlm_hash_lm_password(char *password);
 extern char *ntlm_hash_nt_password(char *password);
 extern char *ntlm2_hash_password(char *username, char *domain, char *password);
-extern int ntlm_request(char **dst, struct auth_s *creds);
+extern int ntlm_request(char **dst, struct auth_s *creds, int ntlm_clean_negotiation);
 extern int ntlm_response(char **dst, char *challenge, int challen, struct auth_s *creds);
 
 #endif /* _NTLM_H */


### PR DESCRIPTION
This PR introduces 2 optional flags:
- `AllowNullWorkstation` which allows workstation to be set to null
- `NTLMCleanNegotiation` which provides alternative, more barebones request flags.

These changes allow `cntlm` to be compatible with a wider range of NTLM proxies.

add to `.conf`:
```
AllowNullWorkStation yes
NTLMCleanNegotiation yes
```